### PR TITLE
Add nonce verification to the Add Member admin form to prevent CSRF

### DIFF
--- a/adminpages/addmember.php
+++ b/adminpages/addmember.php
@@ -117,6 +117,8 @@ if ( ! empty( $_POST['order_notes'] ) ) {
 }
 
 if ( ! empty( $_REQUEST['action'] ) && $_REQUEST['action'] == 'add_member' ) {
+	check_admin_referer( 'pmproama_add_member', 'pmproama_add_member_nonce' );
+
 	// only if we don't have a user yet
 	if ( empty( $user ) && empty( $user->ID ) ) {
 		// check for required fields
@@ -603,6 +605,7 @@ style="display: none;"<?php } ?>>
 		<div>
 			<input type="hidden" name="action" value="add_member" />
 			<?php
+			wp_nonce_field( 'pmproama_add_member', 'pmproama_add_member_nonce' );
 
 			// Adjust submit button text for Add Member or Add Order page.
 			$submit_button_text = ( empty( $user_id ) ) ? esc_html__( 'Add Member', 'pmpro-add-member-admin' ) : esc_html__( 'Add Order', 'pmpro-add-member-admin' );


### PR DESCRIPTION
## Summary
- Adds `wp_nonce_field( 'pmproama_add_member', 'pmproama_add_member_nonce' )` to the Add Member form.
- Adds `check_admin_referer( 'pmproama_add_member', 'pmproama_add_member_nonce' )` before the form-processing block in `adminpages/addmember.php` so requests without a valid nonce die with the standard WP "Are you sure?" page before any user creation runs.

This addresses a reported CSRF (CVSS 8.8) where a logged-in admin could be tricked into visiting a malicious page that auto-submitted a POST to `admin.php?page=pmpro-addmember`, creating an attacker-controlled administrator account.

## Test plan
- [ ] Load the Add Member page as an admin and confirm the form still renders with the new hidden nonce input.
- [ ] Submit the form normally and confirm a new member/order is created.
- [ ] Submit the Add Order flow (`?user=<id>`) and confirm an order is created for the existing user.
- [ ] Replay the PoC from the report (form POST without the nonce) and confirm the request dies with the WP nonce error page and no user is created.
- [ ] Leave the form open >24h, submit, and confirm the expired-nonce error appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)